### PR TITLE
feat: Add in-memory routing

### DIFF
--- a/src/lib/core/InMemoryHistoryApi.svelte.ts
+++ b/src/lib/core/InMemoryHistoryApi.svelte.ts
@@ -1,0 +1,68 @@
+import type { HistoryApi, State } from "$lib/types.js";
+import { LocationState } from "./LocationState.svelte.js";
+
+/**
+ * In-memory implementation of the History API.
+ */
+export class InMemoryHistoryApi extends LocationState implements HistoryApi {
+    scrollRestoration: ScrollRestoration = 'manual';
+    #history = $state<{ state: State; title: string; url: string }[]>([]);
+    #currentIndex = $state(-1);
+    #cleanup: (() => void) | undefined;
+
+    constructor() {
+        super();
+        this.#cleanup = $effect.root(() => {
+            $effect(() => {
+                const entry = this.#getCurrentEntry();
+                if (entry) {
+                    this.url.href = new URL(entry.url, 'http://mem.local').href;
+                    this.state = entry.state;
+                }
+            })
+        })
+    }
+
+    dispose(): void {
+        this.#cleanup?.();
+        this.#cleanup = undefined;
+    }
+
+    #getCurrentEntry() {
+        return this.#currentIndex < 0 ? null : this.#history[this.#currentIndex];
+    }
+
+    get length() {
+        return this.#history.length;
+    }
+
+    pushState(state: State, title: string, url: string): void {
+        this.#history.splice(this.#currentIndex + 1);
+        this.#history.push({ state, title, url });
+        ++this.#currentIndex;
+    }
+
+    replaceState(state: State, title: string, url: string): void {
+        if (this.#currentIndex >= 0) {
+            this.#history[this.#currentIndex] = { state, title, url };
+        }
+        else {
+            this.#history.push({ state, title, url });
+        }
+    }
+
+    go(delta: number): void {
+        const newIndex = this.#currentIndex + delta;
+        if (newIndex >= 0 && newIndex < this.#history.length) {
+            this.#currentIndex = newIndex;
+        }
+    }
+
+    back(): void {
+        this.go(-1);
+    }
+
+    forward(): void {
+        this.go(1);
+    }
+}

--- a/src/lib/core/LocationFull.svelte.test.ts
+++ b/src/lib/core/LocationFull.svelte.test.ts
@@ -79,13 +79,12 @@ describe("LocationFull", () => {
         ])("Should provide the URL, state and method $method via the event object of 'beforeNavigate'.", ({ method, stateFn }) => {
             // Arrange.
             const callback = vi.fn();
-            const state = { test: 'value' };
+            const state = { path: { test: 'value' }, hash: {} };
             location.on('beforeNavigate', callback);
 
             // Act.
             // @ts-expect-error stateFn cannot enumerate history.
             globalThis.window.history[stateFn](state, '', 'http://example.com/other');
-            flushSync();
 
             // Assert.
             expect(callback).toHaveBeenCalledWith({

--- a/src/lib/core/LocationLite.svelte.test.ts
+++ b/src/lib/core/LocationLite.svelte.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect, beforeEach, beforeAll, vi, afterEach, afterAll } from "vitest";
 import { LocationLite } from "./LocationLite.svelte.js";
-import { LocationState } from "./LocationState.svelte.js";
 import type { Hash, Location, State } from "$lib/types.js";
 import { joinPaths } from "./RouterEngine.svelte.js";
 import { init } from "$lib/index.js";
 import { location as iLoc } from "./Location.js";
+import { StockHistoryApi } from "./StockHistoryApi.svelte.js";
 
 describe("LocationLite", () => {
     const initialUrl = "http://example.com/";
@@ -55,15 +55,14 @@ describe("LocationLite", () => {
             // Assert.
             expect(location.url.href).toBe(initialUrl);
         });
-        test("Should use the provided LocationState instance.", () => {
+        test("Should use the provided HistoryApi instance.", () => {
             // Arrange.
-            const locationState = new LocationState();
+            const historyApi = new StockHistoryApi();
             // Act.
-            // @ts-expect-error Parameter not disclosed.
-            const location = new LocationLite(locationState);
+            const location = new LocationLite(historyApi);
 
             // Assert.
-            expect(location.url).toBe(locationState.url);
+            expect(location.url).toBe(historyApi.url);
 
             // Cleanup.
             location.dispose();

--- a/src/lib/core/LocationState.svelte.ts
+++ b/src/lib/core/LocationState.svelte.ts
@@ -1,20 +1,26 @@
 import { SvelteURL } from "svelte/reactivity";
 import { isConformantState } from "./isConformantState.js";
+import type { State } from "$lib/types.js";
 
 /**
- * Helper class used to manage the reactive data of Location implementations.
+ * Base class for implementations of HistoryApi classes.
  */
 export class LocationState {
-    url = new SvelteURL(globalThis.window?.location?.href);
+    #url;
     state;
 
-    constructor() {
+    constructor(initialHref?: string, initialState?: State) {
+        this.#url = new SvelteURL(initialHref || globalThis.window?.location?.href);
         // Get the current state from History API
-        let historyState = globalThis.window?.history?.state;
+        let historyState = initialState ?? globalThis.window?.history?.state;
         let validState = false;
         this.state = $state((validState = isConformantState(historyState)) ? historyState : { path: undefined, hash: {} });
         if (!validState && historyState != null) {
             console.warn('Non-conformant state data detected in History API. Resetting to clean state.');
         }
+    }
+
+    get url() {
+        return this.#url;
     }
 }

--- a/src/lib/core/StockHistoryApi.svelte.ts
+++ b/src/lib/core/StockHistoryApi.svelte.ts
@@ -1,0 +1,66 @@
+import type { HistoryApi, State } from "$lib/types.js";
+import { on } from "svelte/events";
+import { LocationState } from "./LocationState.svelte.js";
+
+export class StockHistoryApi extends LocationState implements HistoryApi {
+    #cleanup: (() => void) | undefined;
+
+    constructor() {
+        super();
+        const cleanups = [] as (() => void)[];
+        ['popstate', 'hashchange'].forEach((event) => {
+            cleanups.push(on(globalThis.window, event, () => {
+                console.log(event);
+                this.url.href = globalThis.window?.location?.href;
+                this.state = globalThis.window?.history?.state;
+            }));
+        });
+        this.#cleanup = () => {
+            cleanups.forEach((cleanup) => cleanup());
+        };
+    }
+
+    #updateState(state: State) {
+        this.state = state;
+        this.url.href = globalThis.window.location.href;
+    }
+
+    dispose(): void {
+        this.#cleanup?.();
+        this.#cleanup = undefined;
+    }
+
+    back(): void {
+        this.go(-1);
+    }
+
+    forward(): void {
+        this.go(1);
+    }
+
+    go(delta?: number): void {
+        globalThis.window?.history.go(delta);
+    }
+
+    pushState(state: State, unused: string, url?: string | URL | null): void {
+        globalThis.window?.history.pushState(state, unused, url);
+        this.#updateState(state);
+    }
+
+    replaceState(state: State, unused: string, url?: string | URL | null): void {
+        globalThis.window?.history.replaceState(state, unused, url);
+        this.#updateState(state);
+    }
+
+    get length() {
+        return globalThis.window?.history.length ?? 0;
+    }
+
+    get scrollRestoration() {
+        return globalThis.window?.history.scrollRestoration ?? "auto";
+    }
+
+    set scrollRestoration(value: ScrollRestoration) {
+        globalThis.window.history.scrollRestoration = value;
+    }
+}

--- a/src/lib/core/options.ts
+++ b/src/lib/core/options.ts
@@ -3,11 +3,6 @@
  */
 export type RoutingOptions = {
     /**
-     * Whether to initialize the routing library with all features.
-     * @default false
-     */
-    full?: boolean;
-    /**
      * Whether to use a single or multiple hash mode.  In single hash mode, the hash value is always one path; in multi 
      * mode, the hash value can be multiple paths.
      * 
@@ -44,7 +39,24 @@ export type RoutingOptions = {
      * as hash-routing components because the `implicitMode` option was set to `'hash'`.
      */
     implicitMode?: 'hash' | 'path';
-}
+} & ({
+    /**
+     * Whether to initialize the routing library with all features.
+     * @default false
+     */
+    full?: true;
+} | {
+    /**
+     * Whether to initialize the routing library with all features.
+     * @default false
+     */
+    full: false;
+    /**
+     * Whether to route in memory only.  This means that the routing library will not modify the browser's history or 
+     * URL, but to every API in the library, it will look like that.
+     */
+    routeInMemory?: boolean;
+})
 
 /**
  * Global routing options.
@@ -52,5 +64,6 @@ export type RoutingOptions = {
 export const routingOptions: Required<RoutingOptions> = {
     full: false,
     hashMode: 'single',
-    implicitMode: 'path'
+    implicitMode: 'path',
+    routeInMemory: false
 };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,7 +1,9 @@
+import { InMemoryHistoryApi } from "./core/InMemoryHistoryApi.svelte.js";
 import { setLocation } from "./core/Location.js";
 import { LocationFull } from "./core/LocationFull.js";
 import { LocationLite } from "./core/LocationLite.svelte.js";
 import { routingOptions, type RoutingOptions } from "./core/options.js";
+import { StockHistoryApi } from "./core/StockHistoryApi.svelte.js";
 import { setTraceOptions, type TraceOptions } from "./core/trace.svelte.js";
 
 /**
@@ -33,7 +35,15 @@ export function init(options?: InitOptions): () => void {
     routingOptions.full = options?.full ?? routingOptions.full;
     routingOptions.hashMode = options?.hashMode ?? routingOptions.hashMode;
     routingOptions.implicitMode = options?.implicitMode ?? routingOptions.implicitMode;
-    const newLocation = setLocation(options?.full ? new LocationFull() : new LocationLite());
+    if (!routingOptions.full) {
+        // @ts-expect-error ts(2339) TS narrowing on options is not possible.
+        routingOptions.routeInMemory = options?.routeInMemory ?? routingOptions.routeInMemory;
+    }
+    const newLocation = setLocation(
+        routingOptions.full ?
+            new LocationFull() :
+            new LocationLite(routingOptions.routeInMemory ? new InMemoryHistoryApi() : new StockHistoryApi())
+    );
     return () => {
         newLocation?.dispose();
         setLocation(null);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -319,3 +319,9 @@ export type ActiveState = {
      */
     ariaCurrent?: HTMLAnchorAttributes['aria-current'];
 }
+
+export interface HistoryApi extends History {
+    readonly url: SvelteURL;
+    state: State;
+    dispose(): void;
+}


### PR DESCRIPTION
FEATURE:  Memory-only routing
Fixes #7.

It is a delta LOC of +117 and I'm not fully convinced that this brings value.

What would be the use case for in-memory routing, other than "quick tests" or unit testing?

Still pending:  Unit testing.

Will let consumers of the package make a case for this feature.