### PR TITLE
chore(ssr):  Only render children if there are no conditions specified

### DIFF
--- a/src/lib/Route/Route.svelte
+++ b/src/lib/Route/Route.svelte
@@ -169,6 +169,6 @@
 	});
 </script>
 
-{#if (router.routeStatus[key]?.match ?? true)}
+{#if (router.routeStatus[key]?.match ?? (!and && !path))}
 	{@render children?.(params, router.state, router.routeStatus)}
 {/if}


### PR DESCRIPTION
This was the original intention, but in SSR (Sveltekit), this is not the reality.

The route component registers its conditions with the router using $effect.pre(), which doesn't run on the server, causing all routes to be briefly visible.