### PR TITLE
fix:  Snapshot state data when normalized to get rid of proxies

### DIFF
--- a/src/lib/kernel/LocationState.svelte.ts
+++ b/src/lib/kernel/LocationState.svelte.ts
@@ -22,6 +22,10 @@ export class LocationState {
 
     /**
      * Normalizes state data to ensure it conforms to the expected State interface.
+     * 
+     * **NOTE**:  In order to avoid serialization errors of the provided data, which might contain reactive Svelte 
+     * proxies, the returned data is a clean snapshot of the normalized data.
+     * 
      * @param state The state to normalize
      * @param defaultState Optional default state to use if normalization is needed
      * @returns Normalized state that conforms to the State interface
@@ -34,6 +38,6 @@ export class LocationState {
             logger.warn(`Non-conformant state data detected. ${action}`);
         }
         
-        return validState ? state : (defaultState ?? { path: undefined, hash: {} });
+        return $state.snapshot(validState ? state : (defaultState ?? { path: undefined, hash: {} }));
     }
 }


### PR DESCRIPTION
Svelte proxies prevent data serialization.  `$state.snapshot()` is now used to ensure a proxy-free data object.